### PR TITLE
Reconfigure docker images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ typings/
 
 # User specific files
 */config/aws.js
+*/env.yml

--- a/server/DEVELOPERS.md
+++ b/server/DEVELOPERS.md
@@ -22,9 +22,9 @@ version: '3'
 services:
   awsuper-server:
     environment:
-        -ACCESS_KEY_ID=<your key>
-        -SECRET_ACESS_KEY=<your secret>
-        -REGION=<your region>
+        - ACCESS_KEY_ID=<your key>
+        - SECRET_ACESS_KEY=<your secret>
+        - REGION=<your region>
 ```
 
 Both `config/aws.js` and `env.yml` are already included in the `.gitignore`, which should streamline PRs by automatically excluding any variables that are specific to your AWS environment.
@@ -33,7 +33,7 @@ Both `config/aws.js` and `env.yml` are already included in the `.gitignore`, whi
 
 Once you've followed the previous steps, this one is easy:
 
-`docker-compose up -f docker-compose.yml -f env.yml --build`.  This will start a container named `awsuper` on your machine, with the appropriate environment variables, and with the `server` directory volume-mounted into the container. It will not start the server, though.
+`docker-compose -f docker-compose.yml -f env.yml up --build`.  This will start a container named `awsuper` on your machine, with the appropriate environment variables, and with the `server` directory volume-mounted into the container. It will not start the server, though.
 
 To get a shell in the container, open a new terminal and enter:
 

--- a/server/DEVELOPERS.md
+++ b/server/DEVELOPERS.md
@@ -1,0 +1,42 @@
+# Contributing to AWSuper
+
+First, thanks for wanting to help!
+
+Second, let's get you set up with a developer environment.
+
+## The Basics
+
+1. [Install Docker and Docker-Compose](https://www.docker.com/products/docker-desktop) for your platform
+2. [Clone down this Repo](https://github.com/shawnrushefsky/awsuper), or even better, your own fork of it.
+3. `cd` into the new directory.
+4. `cd` into the `server` directory
+5. Run `./build-local.sh`. This will create a local docker image, `awsuper:local` that our dev environment will be based on.
+
+## Connecting to your AWS resources
+
+There are 2 ways to accomplish this. You may create a config file as described [here](https://github.com/shawnrushefsky/awsuper/tree/master/server#launching-the-server-locally), or you may specify your credentials through environment variables. A simple way to do this is to create a new file, `env.yml`, that will look like this:
+
+```yml
+version: '3'
+
+services:
+  awsuper-server:
+    environment:
+        -ACCESS_KEY_ID=<your key>
+        -SECRET_ACESS_KEY=<your secret>
+        -REGION=<your region>
+```
+
+Both `config/aws.js` and `env.yml` are already included in the `.gitignore`, which should streamline PRs by automatically excluding any variables that are specific to your AWS environment.
+
+## Launching the Development container
+
+Once you've followed the previous steps, this one is easy:
+
+`docker-compose up -f docker-compose.yml -f env.yml --build`.  This will start a container named `awsuper` on your machine, with the appropriate environment variables, and with the `server` directory volume-mounted into the container. It will not start the server, though.
+
+To get a shell in the container, open a new terminal and enter:
+
+`docker exec -it awsuper bash`.
+
+You can start the server with `npm start`.

--- a/server/Dockerfile-dev
+++ b/server/Dockerfile-dev
@@ -1,36 +1,4 @@
-FROM node:10.4.0-stretch
-
-# Prepare the system to run rabbitmq
-RUN apt-get update && apt-get -y upgrade \
-    && wget -O - 'https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc' | apt-key add - \
-    && echo "deb http://dl.bintray.com/rabbitmq/debian stretch erlang" >> /etc/apt/sources.list \
-    && apt-get update && apt-get install -y erlang-nox \
-    && echo "deb https://dl.bintray.com/rabbitmq/debian stretch main" | tee /etc/apt/sources.list.d/bintray.rabbitmq.list \
-    && apt-get update && apt-get install -y rabbitmq-server
-
-# Get the delayed-message-exchange plugin for rabbitmq
-WORKDIR /usr/lib/rabbitmq/plugins
-
-RUN apt-get install -y unzip \
-    && wget https://dl.bintray.com/rabbitmq/community-plugins/3.7.x/rabbitmq_delayed_message_exchange/rabbitmq_delayed_message_exchange-20171201-3.7.x.zip -O temp.zip \
-    && unzip temp.zip \
-    && rm temp.zip \
-    && rabbitmq-plugins --offline enable rabbitmq_delayed_message_exchange
-
-# Prepare the system to run mongodb
-RUN apt-get install -y mongodb
-
-WORKDIR /data/db
-
-EXPOSE 4242
-
-WORKDIR /code
-
-COPY ./package.json .
-
-RUN npm install
-
-COPY . .
+FROM awsuper:local
 
 CMD service rabbitmq-server start \
     && service mongodb start \

--- a/server/README.md
+++ b/server/README.md
@@ -78,7 +78,7 @@ MONGO_PORT | no | Just the port of your MongoDB primary. Defaults to `27017`.
 
 ## NOTES
 
-AWSuper relies on the [delayed message exchange](https://github.com/rabbitmq/rabbitmq-delayed-message-exchange) plugin for RabbitMQ to handle scheduling, so if you choose not to rely on the rabbitmq that is included with the container, make sure the rabbitmq you point to does include this plugin.
+AWSuper relies on the [delayed message exchange](https://github.com/rabbitmq/rabbitmq-delayed-message-exchange) plugin for RabbitMQ to handle scheduling, so if you choose not to rely on the rabbitmq that is included with the container, make sure the rabbitmq you point to does include this plugin, such as [shawnrushefsky/rabbitmq-delayed-message-exchange](https://hub.docker.com/r/shawnrushefsky/rabbitmq-delayed-message-exchange/).
 
 # Tasks
 

--- a/server/README.md
+++ b/server/README.md
@@ -76,6 +76,10 @@ RABBIT_PORT | no | Just the port of the your RabbitMQ instance, or other AMQP br
 MONGO_HOST | no | Just the hostname of your MongoDB primary. Defaults to `localhost`, as the container includes MongoDB by default.
 MONGO_PORT | no | Just the port of your MongoDB primary. Defaults to `27017`.
 
+## NOTES
+
+AWSuper relies on the [delayed message exchange](https://github.com/rabbitmq/rabbitmq-delayed-message-exchange) plugin for RabbitMQ to handle scheduling, so if you choose not to rely on the rabbitmq that is included with the container, make sure the rabbitmq you point to does include this plugin.
+
 # Tasks
 
 While the AWSuper API provides some basic inspection capabilities of your OpsWorks stacks and Layers, most of it's functionality is provided by a pluggable `Task` framework.

--- a/server/README.md
+++ b/server/README.md
@@ -62,6 +62,20 @@ module.exports = {
 
 When the server starts it will output your auth token, which you will need to use in the Authorization header for every request
 
+# Environment Variables
+
+You may customize the deployment of AWSuper through the use of environment variables:
+
+name | required | description
+-----|----------|-------------
+ACCESS_KEY_ID | yes | Your AWS Access Key ID
+SECRET_ACCESS_KEY | yes | Your AWS Secret Access Key
+REGION | yes | The AWS region you'll be orchestrating, i.e. "us-east-1".
+RABBIT_HOST | no | Just the hostname of your RabbitMQ instance, or other AMQP broker. Defaults to `localhost`, as the container includes RabbitMQ by default.
+RABBIT_PORT | no | Just the port of the your RabbitMQ instance, or other AMQP broker. Defaults to `5672`.
+MONGO_HOST | no | Just the hostname of your MongoDB primary. Defaults to `localhost`, as the container includes MongoDB by default.
+MONGO_PORT | no | Just the port of your MongoDB primary. Defaults to `27017`.
+
 # Tasks
 
 While the AWSuper API provides some basic inspection capabilities of your OpsWorks stacks and Layers, most of it's functionality is provided by a pluggable `Task` framework.

--- a/server/README.md
+++ b/server/README.md
@@ -1,5 +1,7 @@
 # AWSuper Server
 
+[How can I contribute?](https://github.com/shawnrushefsky/awsuper/blob/master/server/DEVELOPERS.md)
+
 # Launching with Docker
 
 The AWSuper server is hosted on [Docker Hub](https://hub.docker.com/r/shawnrushefsky/awsuper/)
@@ -14,13 +16,15 @@ If you are building a docker image from source, instead of using the version hos
 
 ```shell
 cd server
-docker build -t awsuper .
+./build-local.sh
 ```
+
+This builds the image from `./Dockerfile`, and tags it `awsuper:local`.
 
 And then running it with your AWS credentials as environment variables:
 
 ```shell
-docker container run --name awsuper -e ACCESS_KEY_ID=<your key> -e SECRET_ACESS_KEY=<your secret> -e REGION=<your region> -p 4242:4242 awsuper
+docker container run --name awsuper -e ACCESS_KEY_ID=<your key> -e SECRET_ACESS_KEY=<your secret> -e REGION=<your region> -p 4242:4242 awsuper:local
 ```
 
 After outputing your auth token, the server will be listening on port 4242.

--- a/server/build-local.sh
+++ b/server/build-local.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+# get absolute path of this file
+CWD="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# use the 1st command line argument as the tag. Default the tag to qa if one isn't provided
+TAG=${1:-local}
+
+docker build --no-cache \
+    -f ${CWD}/Dockerfile \
+    -t awsuper:${TAG} \
+    ${CWD}

--- a/server/config/index.js
+++ b/server/config/index.js
@@ -1,4 +1,5 @@
 const _ = require('lodash');
+const child_process = require('child-process');
 const log = require('../src/utils/logger');
 
 const base = require('./base');
@@ -45,5 +46,16 @@ config.rabbit.host = process.env.RABBIT_HOST || config.rabbit.host;
 config.rabbit.port = process.env.RABBIT_PORT || config.rabbit.port;
 config.mongo.host = process.env.MONGO_HOST || config.mongo.host;
 config.mongo.port = process.env.MONGO_PORT || config.mongo.port;
+
+// shutdown any unnecessary services, if replacements were specified in the environment
+if (process.env.RABBIT_HOST && process.env.RABBIT_HOST != 'localhost') {
+    log.info('RABBIT_HOST was specified in the environment. Disabling local rabbitmq.');
+    child_process.exec('service rabbitmq-server stop');
+}
+
+if (process.env.MONGO_HOST && process.env.MONGO_HOST != 'localhost') {
+    log.info('MONGO_HOST was specified in the environment. Disabling local mongodb.');
+    child_process.exec('service mongodb stop');
+}
 
 module.exports = config;

--- a/server/config/index.js
+++ b/server/config/index.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const child_process = require('child-process');
+const child_process = require('child_process');
 const log = require('../src/utils/logger');
 
 const base = require('./base');

--- a/server/config/index.js
+++ b/server/config/index.js
@@ -40,4 +40,10 @@ function validAWSConfig(awsConfig) {
 
 const config = _.merge(base, envConfig, awsConfig);
 
+// Prefer environment variables for rabbit and mongo setup, fall back to config files.
+config.rabbit.host = process.env.RABBIT_HOST || config.rabbit.host;
+config.rabbit.port = process.env.RABBIT_PORT || config.rabbit.port;
+config.mongo.host = process.env.MONGO_HOST || config.mongo.host;
+config.mongo.port = process.env.MONGO_PORT || config.mongo.port;
+
 module.exports = config;


### PR DESCRIPTION
This DRYs up the dev dockerfile by just `FROM`-ing a locally built image. It also provides support and documentation for using rabbitmq and mongodb instances that are external to the container, by passing their details in through environment variables.